### PR TITLE
Handle non-ASCII chars in traceback

### DIFF
--- a/code/zato-common/src/zato/common/util.py
+++ b/code/zato-common/src/zato/common/util.py
@@ -825,7 +825,7 @@ def get_full_stack():
     stackstr = trc + ''.join(traceback.format_list(stack))
 
     if not exc is None:
-        stackstr += '  ' + traceback.format_exc().lstrip(trc)
+        stackstr += '  ' + traceback.format_exc().decode('utf-8').lstrip(trc)
 
     return stackstr
 


### PR DESCRIPTION
Avoid hiding original error and traceback with 'UnicodeDecodeError' when traceback contains non-ASCII characters.
